### PR TITLE
로컬호스트는 포트 상관없이 cors 안뜨게 수정

### DIFF
--- a/src/main/java/com/example/board/config/WebConfig.java
+++ b/src/main/java/com/example/board/config/WebConfig.java
@@ -12,9 +12,9 @@ public class WebConfig {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/api/**")
-                        .allowedOrigins("http://127.0.0.1:5500")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                registry.addMapping("/**")
+                		.allowedOriginPatterns("http://localhost:*","http://127.0.0.1:*")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD")
                         .allowedHeaders("*")
                         .allowCredentials(true);
             }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈번호

- 현재없음
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- webconfig cors 모든 로컬호스트 포트에 적용
