### PR TITLE
sales fix, resister member_id, name, email 중복체크 fix

### DIFF
--- a/src/main/java/com/example/board/controller/MemberController.java
+++ b/src/main/java/com/example/board/controller/MemberController.java
@@ -18,12 +18,12 @@ import com.example.board.dto.SalesDTO;
 import com.example.board.model.member.LoginForm;
 import com.example.board.model.member.Member;
 import com.example.board.model.member.MemberJoinForm;
+import com.example.board.model.product.Product;
 import com.example.board.service.MemberService;
 import com.example.board.util.JwtTokenProvider;
 import com.example.board.util.PasswordUtils;
 
-
-
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -31,166 +31,156 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/members")
 public class MemberController {
 	private final MemberService memberService;
-    private final JwtTokenProvider jwtTokenProvider;
+	private final JwtTokenProvider jwtTokenProvider;
 
-    public MemberController(MemberService memberService, JwtTokenProvider jwtTokenProvider) {
-        this.memberService = memberService;
-        this.jwtTokenProvider = jwtTokenProvider;
+	public MemberController(MemberService memberService, JwtTokenProvider jwtTokenProvider) {
+		this.memberService = memberService;
+		this.jwtTokenProvider = jwtTokenProvider;
 
-    }
+	}
 
-    // 유저 등록
-    @PostMapping("/register")
-    public ResponseEntity<MemberJoinForm> registerMember(@RequestBody MemberJoinForm memberJoinForm) {
-        memberService.saveMember(memberJoinForm);
-        return ResponseEntity.ok(memberJoinForm);
-    }
-    
-    
-    // 로그인
-    @PostMapping("/login")
-    public ResponseEntity<Map<String, Object>> login(@RequestBody LoginForm loginForm) {
-        Map<String, Object> response = new HashMap<>();
-        
-        
-        try {
-            // 사용자 인증
-            boolean isAuthenticated = memberService.login(loginForm.getMember_id(), loginForm.getPassword());
-            if (isAuthenticated) {
-                Member member = memberService.findMemberById(loginForm.getMember_id());
-                String token = jwtTokenProvider.createToken(member.getMember_id());
+	// 유저 등록
+	@PostMapping("/register")
+	public ResponseEntity<MemberJoinForm> registerMember(@Valid @RequestBody MemberJoinForm memberJoinForm) {
 
-                response.put("success", true);
-                response.put("message", "로그인 성공");
-                response.put("token", token);
-                response.put("name", member.getName());
-                response.put("member_id", member.getMember_id());  // member_id를 추가로 반환
+		memberService.saveMember(memberJoinForm);
+		return ResponseEntity.ok(memberJoinForm);
+	}
 
-                return ResponseEntity.ok(response);
-            } else {
-                response.put("success", false);
-                response.put("message", "로그인 실패");
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
-            }
-        } catch (Exception e) {
-            log.error("Login error", e);
+	// 로그인
+	@PostMapping("/login")
+	public ResponseEntity<Map<String, Object>> login(@RequestBody LoginForm loginForm) {
+		Map<String, Object> response = new HashMap<>();
 
-            response.put("success", false);
-            response.put("message", "서버 오류");
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
-        }
-    }
-    
-   //마이페이지
-    @GetMapping("/mypage/{member_id}")
-    public ResponseEntity<MemberProfileDto> getMemberProfile(@RequestHeader("Authorization") String token) {
-        String memberId = jwtTokenProvider.getUserIdFromToken(token.replace("Bearer ", ""));
-        if (memberId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+		try {
+			// 사용자 인증
+			boolean isAuthenticated = memberService.login(loginForm.getMember_id(), loginForm.getPassword());
+			if (isAuthenticated) {
+				Member member = memberService.findMemberById(loginForm.getMember_id());
+				String token = jwtTokenProvider.createToken(member.getMember_id());
 
-        MemberProfileDto profile = memberService.getMemberProfile(memberId);
-        if (profile != null) {
-            return ResponseEntity.ok(profile);
-        }
-            else {
-                return ResponseEntity.notFound().build();
-            }
-        }
+				response.put("success", true);
+				response.put("message", "로그인 성공");
+				response.put("token", token);
+				response.put("name", member.getName());
+				response.put("member_id", member.getMember_id()); // member_id를 추가로 반환
 
+				return ResponseEntity.ok(response);
+			} else {
+				response.put("success", false);
+				response.put("message", "로그인 실패");
+				return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+			}
+		} catch (Exception e) {
+			log.error("Login error", e);
 
-    // 유저 1명 조회
-    @GetMapping("/{member_id}")
-    public ResponseEntity<Member> getMember(@PathVariable("member_id") String member_id) {
-        Member member = memberService.findMemberById(member_id);
-        if (member != null) {
-            return ResponseEntity.ok(member);
-        } else {
-            return ResponseEntity.notFound().build();
-        }
-    }
+			response.put("success", false);
+			response.put("message", "서버 오류");
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+		}
+	}
 
-    
-    // 회원 탈퇴
-    @DeleteMapping("/{member_id}")
-    public ResponseEntity<Void> deleteMember(
-            @PathVariable("member_id") String member_id,
-            @RequestParam("password") String password)
-             {
+	// 마이페이지
+	@GetMapping("/mypage/{member_id}")
+	public ResponseEntity<MemberProfileDto> getMemberProfile(@RequestHeader("Authorization") String token) {
+		String memberId = jwtTokenProvider.getUserIdFromToken(token.replace("Bearer ", ""));
+		if (memberId == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
 
-            	// 회원 정보를 조회
-                Member member = memberService.findMemberById(member_id);
-                if (member == null) {
-                    return ResponseEntity.notFound().build();
-                }
+		MemberProfileDto profile = memberService.getMemberProfile(memberId);
+		if (profile != null) {
+			return ResponseEntity.ok(profile);
+		} else {
+			return ResponseEntity.notFound().build();
+		}
+	}
 
-                // 비밀번호 검증
-                boolean isPasswordValid = PasswordUtils.validatePassword(password, member.getPassword());
-                if (!isPasswordValid) {
-                    return ResponseEntity.status(HttpStatus.FORBIDDEN).build(); // 비밀번호가 일치하지 않으면 403 Forbidden 반환
-                }
+	// 유저 1명 조회
+	@GetMapping("/{member_id}")
+	public ResponseEntity<Member> getMember(@PathVariable("member_id") String member_id) {
+		Member member = memberService.findMemberById(member_id);
+		if (member != null) {
+			return ResponseEntity.ok(member);
+		} else {
+			return ResponseEntity.notFound().build();
+		}
+	}
 
-                // 회원 탈퇴 처리
-                boolean isDeleted = memberService.deleteMember(member_id);
-                if (isDeleted) {
-                    return ResponseEntity.noContent().build();
-                } else {
-                    return ResponseEntity.notFound().build();
-                }
-            }
+	// 회원 탈퇴
+	@DeleteMapping("/{member_id}")
+	public ResponseEntity<Void> deleteMember(@PathVariable("member_id") String member_id,
+			@RequestParam("password") String password) {
 
-    // 유저 정보 수정
-    @PutMapping("/{member_id}")
-    public ResponseEntity<Member> updateMemberInfo(
-            @PathVariable("member_id") String member_id,
-            @RequestBody MemberUpdateRequest updateRequest) {
-        try {
-            Member updatedMember = memberService.updateMemberInfo(member_id, updateRequest);
-            if (updatedMember != null) {
-                return ResponseEntity.ok(updatedMember);
-            } else {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
-            }
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
-        }
-    }
-    
-    // 판매 내역 조회
-    @GetMapping("mypage/sales/{member_id}")
-    public ResponseEntity<List<SalesDTO>> getSalesHistory(
-            @PathVariable("member_id") String memberId,
-            @RequestHeader("Authorization") String authorizationHeader) {
+		// 회원 정보를 조회
+		Member member = memberService.findMemberById(member_id);
+		if (member == null) {
+			return ResponseEntity.notFound().build();
+		}
 
+		// 비밀번호 검증
+		boolean isPasswordValid = PasswordUtils.validatePassword(password, member.getPassword());
+		if (!isPasswordValid) {
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).build(); // 비밀번호가 일치하지 않으면 403 Forbidden 반환
+		}
 
-        // Authorization 헤더에서 'Bearer' 접두어 제거
-        String token = authorizationHeader.startsWith("Bearer ") ? 
-                       authorizationHeader.substring(7) : authorizationHeader;
+		// 회원 탈퇴 처리
+		boolean isDeleted = memberService.deleteMember(member_id);
+		if (isDeleted) {
+			return ResponseEntity.noContent().build();
+		} else {
+			return ResponseEntity.notFound().build();
+		}
+	}
 
-        // 토큰 검증 및 멤버 ID 확인
-        if (!jwtTokenProvider.validateToken(token)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid or expired token");
-        }
+	// 유저 정보 수정
+	@PutMapping("/{member_id}")
+	public ResponseEntity<Member> updateMemberInfo(@PathVariable("member_id") String member_id,
+			@RequestBody MemberUpdateRequest updateRequest) {
+		try {
+			Member updatedMember = memberService.updateMemberInfo(member_id, updateRequest);
+			if (updatedMember != null) {
+				return ResponseEntity.ok(updatedMember);
+			} else {
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+			}
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+		}
+	}
 
-        String tokenMemberId = jwtTokenProvider.getUserIdFromToken(token);
+	// 판매 내역 조회
+	@GetMapping("mypage/sales/{member_id}")
+	public ResponseEntity<List<Product>> getSalesHistory(@PathVariable("member_id") String memberId,
+			@RequestHeader("Authorization") String authorizationHeader) {
 
-        // 요청한 멤버 ID와 토큰에서 얻은 멤버 ID가 일치하는지 확인
-        if (!memberId.equals(tokenMemberId)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
-        }
+		// Authorization 헤더에서 'Bearer' 접두어 제거
+		String token = authorizationHeader.startsWith("Bearer ") ? authorizationHeader.substring(7)
+				: authorizationHeader;
 
-        // 판매 내역 조회
-        List<SalesDTO> salesHistory = memberService.getSalesHistory(memberId);
-        return ResponseEntity.ok(salesHistory);
-    }
+		// 토큰 검증 및 멤버 ID 확인
+		if (!jwtTokenProvider.validateToken(token)) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid or expired token");
+		}
 
-   
-    // 로그아웃 (JWT 기반에서는 특별한 로그아웃 처리가 필요하지 않음)
-    @PostMapping("/logout")
-    public ResponseEntity<Void> logout() {
-        // JWT 기반에서는 서버에서 세션을 관리하지 않으므로 로그아웃 시 특별한 처리를 할 필요가 없습니다.
-        // 클라이언트가 토큰을 폐기하거나, 서버에서 토큰을 블랙리스트에 추가하는 등의 방법을 사용할 수 있습니다.
-        return ResponseEntity.noContent().build();
+		String tokenMemberId = jwtTokenProvider.getUserIdFromToken(token);
 
-    }
+		// 요청한 멤버 ID와 토큰에서 얻은 멤버 ID가 일치하는지 확인
+		if (!memberId.equals(tokenMemberId)) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+		}
+
+		// 판매 내역 조회
+		List<Product> salesHistory = memberService.getSalesHistory(memberId);
+		return ResponseEntity.ok(salesHistory);
+	}
+
+	// 로그아웃 (JWT 기반에서는 특별한 로그아웃 처리가 필요하지 않음)
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logout() {
+		// JWT 기반에서는 서버에서 세션을 관리하지 않으므로 로그아웃 시 특별한 처리를 할 필요가 없습니다.
+		// 클라이언트가 토큰을 폐기하거나, 서버에서 토큰을 블랙리스트에 추가하는 등의 방법을 사용할 수 있습니다.
+		return ResponseEntity.noContent().build();
+
+	}
 }

--- a/src/main/java/com/example/board/repository/MemberRepository.java
+++ b/src/main/java/com/example/board/repository/MemberRepository.java
@@ -3,10 +3,20 @@ package com.example.board.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.board.model.member.Member;
 
-public interface MemberRepository extends JpaRepository<Member, String>{
-	 Optional<Member> findByEmail(String email);
+public interface MemberRepository extends JpaRepository<Member, String> {
+	Optional<Member> findByEmail(String email);
+
+	 @Query("SELECT CASE WHEN COUNT(m) > 0 THEN TRUE ELSE FALSE END FROM Member m WHERE m.member_id = :member_id")
+	    boolean existsByMember_id(@Param("member_id") String member_id);
+	// email 중복 여부 확인
+	boolean existsByEmail(String email);
+
+	// name 중복 여부 확인
+	boolean existsByName(String name);
 
 }

--- a/src/main/java/com/example/board/service/MemberService.java
+++ b/src/main/java/com/example/board/service/MemberService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -29,158 +28,152 @@ import com.example.board.util.PasswordUtils;
 
 import lombok.RequiredArgsConstructor;
 
-
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
 	private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final ProductRepository productRepository;
-    private final PurchaseRepository purchaseRepository;
-
+	private final PasswordEncoder passwordEncoder;
+	private final ProductRepository productRepository;
+	private final PurchaseRepository purchaseRepository;
 
 //    public MemberService(MemberRepository memberRepository) {
 //        this.memberRepository = memberRepository;
 //        this.passwordEncoder = new BCryptPasswordEncoder(); // BCryptPasswordEncoder 인스턴스 생성
 //    }
-    
-    
-    @Transactional
-    public void saveMember(MemberJoinForm memberJoinForm) {
-        Member member = new Member();
-        member.setMember_id(memberJoinForm.getMember_id());
-        member.setPassword(PasswordUtils.hashPassword(memberJoinForm.getPassword())); // 비밀번호 해시화
-        member.setName(memberJoinForm.getName());
-        member.setEmail(memberJoinForm.getEmail());
 
-        memberRepository.save(member);
-    }
+	@Transactional
+	public void saveMember(MemberJoinForm memberJoinForm) {
+		// member_id 중복 확인
+		if (memberRepository.existsByMember_id(memberJoinForm.getMember_id())) {
+			throw new IllegalArgumentException("이미 존재하는 회원 ID입니다.");
+		}
 
-    public Member findMemberById(String member_id) {
-        return memberRepository.findById(member_id).orElse(null);
-    }
+		// email 중복 확인
+		if (memberRepository.existsByEmail(memberJoinForm.getEmail())) {
+			throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+		}
 
-    @Transactional
-    public boolean deleteMember(String member_id) {
-        Optional<Member> member = memberRepository.findById(member_id);
-        if (member.isPresent()) {
-            memberRepository.delete(member.get());
-            return true;
-        }
-        return false;
-    }
+		// name 중복 확인
+		if (memberRepository.existsByName(memberJoinForm.getName())) {
+			throw new IllegalArgumentException("이미 존재하는 이름입니다.");
+		}
 
-    @Transactional
-    public Member updateMemberInfo(String member_id, MemberUpdateRequest updateRequest) {
-        
-    	
-    	
-    	Optional<Member> existingMemberOpt = memberRepository.findById(member_id);
-        if (existingMemberOpt.isPresent()) {
-            Member memberToUpdate = existingMemberOpt.get();
+		// 중복 검사를 모두 통과한 경우에만 회원 저장
 
-            // 업데이트할 필드들을 설정
-            if (updateRequest.getName() != null) memberToUpdate.setName(updateRequest.getName());
-            if (updateRequest.getEmail() != null) memberToUpdate.setEmail(updateRequest.getEmail());
-            if (updateRequest.getNewPassword() != null) 
-            	 memberToUpdate.setPassword(passwordEncoder.encode(updateRequest.getNewPassword())); // 비밀번호 해시화
+		Member member = new Member();
+		member.setMember_id(memberJoinForm.getMember_id());
+		member.setPassword(PasswordUtils.hashPassword(memberJoinForm.getPassword())); // 비밀번호 해시화
+		member.setName(memberJoinForm.getName());
+		member.setEmail(memberJoinForm.getEmail());
 
-            return memberRepository.save(memberToUpdate); // 성공적으로 업데이트된 Member 객체 반환
-        }
-        return null; // 업데이트 실패
-    }
+		memberRepository.save(member);
+	}
 
+	public Member findMemberById(String member_id) {
+		return memberRepository.findById(member_id).orElse(null);
+	}
 
-    public boolean login(String member_id, String password) {
-        Optional<Member> memberOpt = memberRepository.findById(member_id);
-        if (memberOpt.isPresent()) {
-            Member member = memberOpt.get();
-            boolean isPasswordValid = PasswordUtils.validatePassword(password, member.getPassword());
-            if (isPasswordValid) {
-                return true; // 비밀번호 일치
-            } else {
-                // 비밀번호 불일치 로그 추가
-                System.out.println("비밀번호 불일치: member_id = " + member_id);
-            }
-        } else {
-            // 회원이 존재하지 않음 로그 추가
-            System.out.println("회원 존재하지 않음: member_id = " + member_id);
-        }
-        return false; // 로그인 실패
-    }
-    
-    
-    public MemberProfileDto getMemberProfile(String member_id) {
-        Member member = memberRepository.findById(member_id)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+	@Transactional
+	public boolean deleteMember(String member_id) {
+		Optional<Member> member = memberRepository.findById(member_id);
+		if (member.isPresent()) {
+			memberRepository.delete(member.get());
+			return true;
+		}
+		return false;
+	}
 
-        return new MemberProfileDto(
-            member.getMember_id(),
-            member.getName(),
-            member.getEmail(),
-            member.getEco_point()
-        );
-    }
+	@Transactional
+	public Member updateMemberInfo(String member_id, MemberUpdateRequest updateRequest) {
 
+		Optional<Member> existingMemberOpt = memberRepository.findById(member_id);
+		if (existingMemberOpt.isPresent()) {
+			Member memberToUpdate = existingMemberOpt.get();
 
-    @Transactional
-    public boolean updatePassword(String member_id, String currentPassword, String newPassword, String confirmNewPassword) {
-        Optional<Member> memberOpt = memberRepository.findById(member_id);
-        if (memberOpt.isPresent()) {
-            Member member = memberOpt.get();
+			// 업데이트할 필드들을 설정
+			if (updateRequest.getName() != null)
+				memberToUpdate.setName(updateRequest.getName());
+			if (updateRequest.getEmail() != null)
+				memberToUpdate.setEmail(updateRequest.getEmail());
+			if (updateRequest.getNewPassword() != null)
+				memberToUpdate.setPassword(passwordEncoder.encode(updateRequest.getNewPassword())); // 비밀번호 해시화
 
-            // 비밀번호 검증
-            if (!passwordEncoder.matches(currentPassword, member.getPassword())) {
-                return false; // 현재 비밀번호가 일치하지 않음
-            }
-            if (!newPassword.equals(confirmNewPassword)) {
-                return false; // 새로운 비밀번호와 확인 비밀번호가 일치하지 않음
-            }
+			return memberRepository.save(memberToUpdate); // 성공적으로 업데이트된 Member 객체 반환
+		}
+		return null; // 업데이트 실패
+	}
 
-            member.setPassword(passwordEncoder.encode(newPassword)); // 비밀번호 해시화
-            memberRepository.save(member);
-            return true;
-        }
-        return false; // 회원이 존재하지 않음
-    }
-    
-    // 판매 이력 가져오기
-    @Transactional
-    public List<SalesDTO> getSalesHistory(String memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
-                
-        List<Product> products = productRepository.findByMember(member);
-        return products.stream()
-                .map(product -> {
-                    SalesDTO dto = new SalesDTO();
-                    dto.setProductId(product.getProduct_id());
-                    dto.setTitle(product.getTitle());
-                    dto.setContents(product.getContents());
-                    dto.setPrice(product.getPrice());
-                    dto.setCreatedTime(product.getCreated_time());
-                    return dto;
-                })
-                .collect(Collectors.toList());
-    }
+	public boolean login(String member_id, String password) {
+		Optional<Member> memberOpt = memberRepository.findById(member_id);
+		if (memberOpt.isPresent()) {
+			Member member = memberOpt.get();
+			boolean isPasswordValid = PasswordUtils.validatePassword(password, member.getPassword());
+			if (isPasswordValid) {
+				return true; // 비밀번호 일치
+			} else {
+				// 비밀번호 불일치 로그 추가
+				System.out.println("비밀번호 불일치: member_id = " + member_id);
+			}
+		} else {
+			// 회원이 존재하지 않음 로그 추가
+			System.out.println("회원 존재하지 않음: member_id = " + member_id);
+		}
+		return false; // 로그인 실패
+	}
 
-    // 구매 이력 가져오기
-    @Transactional
-    public List<PurchaseDTO> getPurchaseHistory(String memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
-                
-        List<Purchase> purchases = purchaseRepository.findByBuyerId(memberId);
-        return purchases.stream()
-                .map(purchase -> {
-                    PurchaseDTO dto = new PurchaseDTO();
-                    dto.setId(purchase.getId());
-                    dto.setProductId(purchase.getProduct().getProduct_id());
-                    dto.setProductTitle(purchase.getProduct().getTitle());
-                    dto.setPurchaseDate(purchase.getPurchaseDate());
-                    return dto;
-                })
-                .collect(Collectors.toList());
-    }
+	public MemberProfileDto getMemberProfile(String member_id) {
+		Member member = memberRepository.findById(member_id)
+				.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		return new MemberProfileDto(member.getMember_id(), member.getName(), member.getEmail(), member.getEco_point());
+	}
+
+	@Transactional
+	public boolean updatePassword(String member_id, String currentPassword, String newPassword,
+			String confirmNewPassword) {
+		Optional<Member> memberOpt = memberRepository.findById(member_id);
+		if (memberOpt.isPresent()) {
+			Member member = memberOpt.get();
+
+			// 비밀번호 검증
+			if (!passwordEncoder.matches(currentPassword, member.getPassword())) {
+				return false; // 현재 비밀번호가 일치하지 않음
+			}
+			if (!newPassword.equals(confirmNewPassword)) {
+				return false; // 새로운 비밀번호와 확인 비밀번호가 일치하지 않음
+			}
+
+			member.setPassword(passwordEncoder.encode(newPassword)); // 비밀번호 해시화
+			memberRepository.save(member);
+			return true;
+		}
+		return false; // 회원이 존재하지 않음
+	}
+
+	// 판매 이력 가져오기
+	@Transactional
+	public List<Product> getSalesHistory(String memberId) {
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		return productRepository.findByMember(member);
+	}
+
+	// 구매 이력 가져오기
+	@Transactional
+	public List<PurchaseDTO> getPurchaseHistory(String memberId) {
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		List<Purchase> purchases = purchaseRepository.findByBuyerId(memberId);
+		return purchases.stream().map(purchase -> {
+			PurchaseDTO dto = new PurchaseDTO();
+			dto.setId(purchase.getId());
+			dto.setProductId(purchase.getProduct().getProduct_id());
+			dto.setProductTitle(purchase.getProduct().getTitle());
+			dto.setPurchaseDate(purchase.getPurchaseDate());
+			return dto;
+		}).collect(Collectors.toList());
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용
> memberService : 판매 이력을 productRepository.findByMember(member);로 리턴하도록 수정
> member_id, name, email 중복체크 기능 추가
> 회원가입 시 글자 수 제한 컨트롤러에 반영



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
